### PR TITLE
feat: migrated set and get head state functions to wayland-rs 0.3

### DIFF
--- a/src/wayland.rs
+++ b/src/wayland.rs
@@ -79,7 +79,7 @@ impl WayoutConnection {
         {
             Ok(x) => x,
             Err(e) => {
-                panic!("Failed to bind to required wayaland global: {}", e);
+                panic!("Failed to bind to required wayland global: {}", e);
             }
         };
 
@@ -93,7 +93,7 @@ impl WayoutConnection {
         event_queue.roundtrip(&mut state).unwrap();
     }
 
-    pub fn get_output_state(self: &Self) -> Vec<OutputState> {
+    pub fn get_output_states(self: &Self) -> Vec<OutputState> {
         let mut event_queue = self.wl_connection.new_event_queue::<OutputState>();
         let qh = event_queue.handle();
 
@@ -115,8 +115,8 @@ impl WayoutConnection {
             };
             zwlr_output_power_manager.get_output_power(&output.wl_output, &qh, ());
 
-            states.push(state.clone());
             event_queue.blocking_dispatch(&mut state).unwrap();
+            states.push(state.clone());
         }
 
         //event_queue.roundtrip(&mut state).unwrap();

--- a/src/wayout.rs
+++ b/src/wayout.rs
@@ -13,22 +13,6 @@ pub struct HeadState {
     mode: Mode,
 }
 pub fn main() {
-    let mut wayout_conn = WayoutConnection::init();
-    wayout_conn.refresh_outputs();
-
-    let output = wayout_conn.get_wloutput("WL-1".to_string()).unwrap();
-    wayout_conn.set_output_state(output, Mode::On);
-
-    for i in wayout_conn.wl_outputs.clone().into_iter() {
-        println!("{}", i);
-    }
-
-    let v = wayout_conn.get_output_state();
-    for head in v {
-        println!("{} {:?}", head.name, head.mode);
-    }
-    return;
-
     let args = flags::parse_flags();
     let mut output_name = String::new();
 
@@ -68,73 +52,25 @@ pub fn main() {
 }
 
 pub fn set_head_state(output_name: String, mode: Mode) {
-    /* let display = Display::connect_to_env().unwrap();
-    let mut event_queue = display.create_event_queue();
-    let attached_display = display.attach(event_queue.token());
-    let globals = GlobalManager::new(&attached_display);
-    event_queue.sync_roundtrip(&mut (), |_, _, _| {}).unwrap();
-
-    let valid_outputs = output::get_all_outputs(display);
-    let output_power_manager = globals.instantiate_exact::<ZwlrOutputPowerManagerV1>(1);
-    event_queue.sync_roundtrip(&mut (), |_, _, _| {}).unwrap();
-
-    let output_choice = output::get_wloutput(output_name, valid_outputs);
-    output_power_manager
-        .as_ref()
-        .unwrap()
-        .get_output_power(&output_choice)
-        .set_mode(mode);
-    event_queue.sync_roundtrip(&mut (), |_, _, _| {}).unwrap(); */
-}
-pub fn get_head_states() -> Vec<HeadState> {
-    /* let display = Display::connect_to_env().unwrap();
-    let mut event_queue = display.create_event_queue();
-    let attached_display = display.attach(event_queue.token());
-    let globals = GlobalManager::new(&attached_display);
-    event_queue
-        .dispatch(&mut (), |_, _, _| unreachable!())
-        .unwrap();
-    let valid_outputs = output::get_all_outputs(display);
-    let output_power_manager = globals.instantiate_exact::<ZwlrOutputPowerManagerV1>(1);
-    let head_states: Rc<RefCell<Vec<HeadState>>> = Rc::new(RefCell::new(Vec::new()));
-
-    for output in valid_outputs {
-        let output_name = output.name;
-        let output_ptr = &output.wl_output;
-        output_power_manager
-            .as_ref()
-            .unwrap()
-            .get_output_power(output_ptr)
-            .quick_assign({
-                let head_states = head_states.clone();
-                let output_name = output_name.clone();
-                move |_, event, _| match event {
-                    zwlr_output_power_v1::Event::Mode { mode } => match mode {
-                        Mode::On => {
-                            head_states.borrow_mut().push(HeadState {
-                                name: output_name.clone(),
-                                mode,
-                            });
-                        }
-                        Mode::Off => {
-                            head_states.borrow_mut().push(HeadState {
-                                name: output_name.clone(),
-                                mode,
-                            });
-                        }
-                        _ => unreachable!(),
-                    },
-                    zwlr_output_power_v1::Event::Failed {} => {
-                        println!("Compositor returned Failed event.");
-                        exit(1);
-                    }
-                    _ => unreachable!(),
-                }
-            });
+    let mut wayout_conn = WayoutConnection::init();
+    wayout_conn.refresh_outputs();
+    
+    if let Some(output) = wayout_conn.get_wloutput(output_name) {
+        wayout_conn.set_output_state(output, mode);
     }
-    event_queue.sync_roundtrip(&mut (), |_, _, _| {}).unwrap();
-    let head_states = head_states.borrow_mut().to_vec();
-    head_states */
+}
 
-    return vec![];
+pub fn get_head_states() -> Vec<HeadState> {
+    let mut wayout_conn = WayoutConnection::init();
+    wayout_conn.refresh_outputs();
+    
+    let output_states = wayout_conn.get_output_states();
+    
+    output_states
+        .into_iter()
+        .map(|state| HeadState {
+            name: state.name,
+            mode: state.mode,
+        })
+        .collect()
 }


### PR DESCRIPTION
Changes made:
`wayland.rs`
- Called blocking dispatch for output state before pushing it to states
vector
- Fix minor typo in panic message
- Better function name `get_output_state()` -> `get_output_states()`

`wayout.rs`
- Now using the new functions in wayland.rs to get and set the output
states
- Cleaned up the hardcoded tests